### PR TITLE
remove redundant "data/tensor.hpp"

### DIFF
--- a/test/test_tensor.cpp
+++ b/test/test_tensor.cpp
@@ -1,7 +1,6 @@
 //
 // Created by fss on 22-12-14.
 //
-#include "data/tensor.hpp"
 #include <gtest/gtest.h>
 #include <armadillo>
 #include <glog/logging.h>


### PR DESCRIPTION
In [`test/test_tensor.cpp`](https://github.com/zjhellofss/KuiperCourse/blob/second/test/test_tensor.cpp), [the header](https://github.com/zjhellofss/KuiperCourse/blob/second/test/test_tensor.cpp#L4) is:
```C++
#include "data/tensor.hpp"
#include <gtest/gtest.h>
#include <armadillo>
#include <glog/logging.h>
#include "data/tensor.hpp"
```

The `tensor.hpp`  is included tiwce, maybe it seems better to remove one of them. 
